### PR TITLE
Fixes #41: add UIManager and NativeMethodsMixin

### DIFF
--- a/Libraries/ActivityIndicator/ActivityIndicator.web.js
+++ b/Libraries/ActivityIndicator/ActivityIndicator.web.js
@@ -11,6 +11,7 @@ import View from 'ReactView';
 import StyleSheet from 'ReactStyleSheet';
 import assign from 'domkit/appendVendorPrefix';
 import insertKeyframesRule from 'domkit/insertKeyframesRule';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 const keyframes = {
   '50%': {
@@ -26,6 +27,7 @@ const GRAY = '#999999';
 var animationName = insertKeyframesRule(keyframes);
 
 var ActivityIndicator = React.createClass({
+  mixins: [NativeMethodsMixin],
 
   propTypes: {
     /**

--- a/Libraries/Animated/AnimatedImplementation.js
+++ b/Libraries/Animated/AnimatedImplementation.js
@@ -1044,12 +1044,20 @@ function createAnimatedComponent(Component: any): any {
       // need to re-render it. In this case, we have a fallback that uses
       // forceUpdate.
       var callback = () => {
+
+        // N.B. the current setNativeProps implementation is not reliable:
+        // it doesn't support the same props/style as when setting a prop
+        // so we disable Animated setNativeProps call and just do forceUpdate()
+        /*
         if (this.refs[refName].setNativeProps) {
           var value = this._propsAnimated.__getAnimatedValue();
           this.refs[refName].setNativeProps(value);
         } else {
-          this.forceUpdate();
+        */
+        this.forceUpdate();
+        /*
         }
+        */
       };
 
       this._propsAnimated = new AnimatedProps(

--- a/Libraries/DrawerLayout/DrawerLayout.web.js
+++ b/Libraries/DrawerLayout/DrawerLayout.web.js
@@ -12,6 +12,7 @@ import View from 'ReactView';
 import Animated from 'ReactAnimated';
 import PanResponder from 'ReactPanResponder';
 import Dimensions from 'ReactDimensions';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 const DEVICE_WIDTH = parseFloat(Dimensions.get('window').width);
 const THRESHOLD = DEVICE_WIDTH / 2;
@@ -22,6 +23,7 @@ const DRAGGING = 'Dragging';
 const SETTLING = 'Settling';
 
 var DrawerLayout = React.createClass({
+  mixins: [NativeMethodsMixin],
 
   statics: {
     positions: {

--- a/Libraries/Image/Image.web.js
+++ b/Libraries/Image/Image.web.js
@@ -10,13 +10,14 @@ import React from 'react';
 import View from 'ReactView';
 import { Mixin as LayoutMixin } from 'ReactLayoutMixin';
 import ImageResizeMode from './ImageResizeMode';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 var Image = React.createClass({
   statics: {
     resizeMode: ImageResizeMode,
   },
 
-  mixins: [LayoutMixin],
+  mixins: [LayoutMixin, NativeMethodsMixin],
 
   contextTypes: {
     isInAParentText: React.PropTypes.bool

--- a/Libraries/ProgressView/ProgressView.web.js
+++ b/Libraries/ProgressView/ProgressView.web.js
@@ -9,8 +9,10 @@
 import React from 'react';
 import View from 'ReactView';
 import StyleSheet from 'ReactStyleSheet';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 var ProgressView = React.createClass({
+  mixins: [NativeMethodsMixin],
   render: function() {
 
     var specificStyle = {

--- a/Libraries/SegmentedControl/SegmentedControl.web.js
+++ b/Libraries/SegmentedControl/SegmentedControl.web.js
@@ -12,8 +12,11 @@ import React, { PropTypes } from 'react';
 import View from 'ReactView';
 import Text from 'ReactText';
 import StyleSheet from 'ReactStyleSheet';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 var SegmentedControl = React.createClass({
+  mixins: [NativeMethodsMixin],
+
   propTypes: {
     /**
      * The labels for the control's segment buttons, in order.

--- a/Libraries/Switch/Switch.web.js
+++ b/Libraries/Switch/Switch.web.js
@@ -7,8 +7,10 @@
 'use strict';
 
 import React, { PropTypes } from 'react';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 var Switch = React.createClass({
+  mixins: [NativeMethodsMixin],
 
   propTypes: {
     value: PropTypes.bool,

--- a/Libraries/Text/Text.web.js
+++ b/Libraries/Text/Text.web.js
@@ -11,6 +11,7 @@
 import React from 'react';
 import { Mixin as TouchableMixin } from 'ReactTouchable';
 import { Mixin as LayoutMixin } from 'ReactLayoutMixin';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 /**
  * A React component for displaying text which supports nesting,
@@ -47,7 +48,7 @@ import { Mixin as LayoutMixin } from 'ReactLayoutMixin';
 
 var Text = React.createClass({
 
-  mixins: [LayoutMixin, TouchableMixin],
+  mixins: [LayoutMixin, TouchableMixin, NativeMethodsMixin],
 
   propTypes: {
     /**

--- a/Libraries/Touchable/TouchableHighlight.web.js
+++ b/Libraries/Touchable/TouchableHighlight.web.js
@@ -13,6 +13,7 @@ import View from 'ReactView';
 import TimerMixin from 'react-timer-mixin';
 import TouchableWithoutFeedback from 'ReactTouchableWithoutFeedback';
 import { Mixin as TouchableMixin } from 'ReactTouchable';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 import StyleSheet from 'ReactStyleSheet';
 
 type Event = Object;
@@ -55,7 +56,7 @@ var TouchableHighlight = React.createClass({
     onHideUnderlay: React.PropTypes.func,
   },
 
-  mixins: [TimerMixin, TouchableMixin],
+  mixins: [TimerMixin, TouchableMixin, NativeMethodsMixin],
 
   getDefaultProps: () => DEFAULT_PROPS,
 

--- a/Libraries/Touchable/TouchableOpacity.web.js
+++ b/Libraries/Touchable/TouchableOpacity.web.js
@@ -13,6 +13,7 @@ import React from 'react';
 import TimerMixin from 'react-timer-mixin';
 import { Mixin as TouchableMixin } from 'ReactTouchable';
 import TouchableWithoutFeedback from 'ReactTouchableWithoutFeedback';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 // var ensurePositiveDelayProps = require('ensurePositiveDelayProps');
 var flattenStyle = require('ReactFlattenStyle');
@@ -42,7 +43,7 @@ type Event = Object;
  */
 
 var TouchableOpacity = React.createClass({
-  mixins: [TimerMixin, TouchableMixin],
+  mixins: [TimerMixin, TouchableMixin, NativeMethodsMixin],
 
   propTypes: {
     ...TouchableWithoutFeedback.propTypes,

--- a/Libraries/Utilties/NativeMethodsMixin.web.js
+++ b/Libraries/Utilties/NativeMethodsMixin.web.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2015-present, Alibaba Group Holding Limited.
+ * All rights reserved.
+ *
+ * @providesModule NativeMethodsMixin
+ */
+'use strict';
+
+import UIManager from 'UIManager';
+
+import ReactDOM from 'react-dom';
+import setNativeProps from 'ReactSetNativeProps';
+
+
+var NativeMethodsMixin = {
+  /**
+   * Determines the location on screen, width, and height of the given view and
+   * returns the values via an async callback. If successful, the callback will
+   * be called with the following arguments:
+   *
+   *  - x
+   *  - y
+   *  - width
+   *  - height
+   *  - pageX
+   *  - pageY
+   *
+   * Note that these measurements are not available until after the rendering
+   * has been completed in native. If you need the measurements as soon as
+   * possible, consider using the [`onLayout`
+   * prop](/react-native/docs/view.html#onlayout) instead.
+   */
+  measure: function(callback) {
+    UIManager.measure(
+      ReactDOM.findDOMNode(this),
+      mountSafeCallback(this, callback)
+    );
+  },
+
+  /**
+   * Like [`measure()`](#measure), but measures the view relative an ancestor,
+   * specified as `relativeToNativeNode`. This means that the returned x, y
+   * are relative to the origin x, y of the ancestor view.
+   *
+   * As always, to obtain a native node handle for a component, you can use
+   * `ReactDOM.findDOMNode(component)`.
+   */
+  measureLayout: function(relativeToNativeNode, onSuccess, onFail) {
+    UIManager.measureLayout(
+      ReactDOM.findDOMNode(this),
+      relativeToNativeNode,
+      mountSafeCallback(this, onFail),
+      mountSafeCallback(this, onSuccess)
+    );
+  },
+
+  /**
+   * This function sends props straight to native. They will not participate in
+   * future diff process - this means that if you do not include them in the
+   * next render, they will remain active (see [Direct
+   * Manipulation](/react-native/docs/direct-manipulation.html)).
+   */
+  setNativeProps: function(nativeProps) {
+    setNativeProps(ReactDOM.findDOMNode(this), nativeProps);
+  },
+
+  /**
+   * Requests focus for the given input or view. The exact behavior triggered
+   * will depend on the platform and type of view.
+   */
+  focus: function() {
+    ReactDOM.findDOMNode(this).focus();
+  },
+
+  /**
+   * Removes focus from an input or view. This is the opposite of `focus()`.
+   */
+  blur: function() {
+    ReactDOM.findDOMNode(this).blur();
+  }
+};
+
+/**
+ * In the future, we should cleanup callbacks by cancelling them instead of
+ * using this.
+ */
+var mountSafeCallback = function(context, callback) {
+  return function() {
+    if (!callback || context.isMounted && !context.isMounted()) {
+      return;
+    }
+    return callback.apply(context, arguments);
+  };
+};
+
+module.exports = { Mixin: NativeMethodsMixin };

--- a/Libraries/Utilties/UIManager.web.js
+++ b/Libraries/Utilties/UIManager.web.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2015-present, Alibaba Group Holding Limited.
+ * All rights reserved.
+ *
+ * @providesModule UIManager
+ */
+
+const UIManager = {
+  measure: (ref, callback) => {
+    const rect = ref.getBoundingClientRect();
+    callback(0, 0, rect.width, rect.height, rect.left, rect.top);
+  },
+  measureLayout: (ref, relativeTo, errorCallback, callback) => {
+    const rect = ref.getBoundingClientRect();
+    const relativeRef = relativeTo.getBoundingClientRect();
+    callback(
+      rect.left - relativeRef.left,
+      rect.top - relativeRef.top,
+      rect.width,
+      rect.height);
+  }
+};
+
+module.exports = UIManager;

--- a/Libraries/View/View.web.js
+++ b/Libraries/View/View.web.js
@@ -11,9 +11,10 @@
 import React, { PropTypes } from 'react';
 import StyleSheet from 'ReactStyleSheet';
 import { Mixin as LayoutMixin } from 'ReactLayoutMixin';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 var View = React.createClass({
-  mixins: [LayoutMixin],
+  mixins: [LayoutMixin, NativeMethodsMixin],
 
   propTypes: {
     /**

--- a/Libraries/ViewPager/ViewPager.web.js
+++ b/Libraries/ViewPager/ViewPager.web.js
@@ -14,11 +14,14 @@ import Animated from 'ReactAnimated';
 import Dimensions from 'ReactDimensions';
 import PanResponder from 'ReactPanResponder';
 import dismissKeyboard from 'ReactDismissKeyboard';
+import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 
 const deviceSize = Dimensions.get('window');
 const VIEWPAGER_REF = 'viewpager';
 
 var ViewPager = React.createClass({
+  mixins: [NativeMethodsMixin],
+
   propTypes: {
     /**
      * Index of initial page that should be selected. Use `setPage` method to


### PR DESCRIPTION
fixes #41

now we can use `ref.setNativeProps()` as well as `ref.measure(cb)` and `measureLayout` on some native components like View and Text.

UIManager is also exposed (like in RN) and you can progressively add all the remaining methods as you need them.