### PR TITLE
Fixes transform value (like scale, scaleX,..) that are in [0,1] range to not be set to 1

### DIFF
--- a/Libraries/StyleSheet/extendProperties.web.js
+++ b/Libraries/StyleSheet/extendProperties.web.js
@@ -16,10 +16,14 @@ var shorthandProperties = {
 };
 
 // some number that react not auto add px
-var numberProperties = {
+var numberTransformProperties = {
   translateX: true,
   translateY: true,
-  translateZ: true,
+  translateZ: true
+};
+
+// some number that react not auto add px
+var numberProperties = {
   lineHeight: true
 };
 
@@ -126,6 +130,13 @@ function isValidValue(value) {
   return value !== '' && value !== null && value !== undefined;
 }
 
+function processTransformValue(value, key) {
+  if (numberTransformProperties[key] && typeof value == 'number') {
+    value += 'px';
+  }
+  return value;
+}
+
 function processValueForProp(value, prop) {
 
   if (typeof value == 'number') {
@@ -166,11 +177,11 @@ function processValueForProp(value, prop) {
         }
 
         val = val.map(function(v) {
-          return processValueForProp(v, key);
+          return processTransformValue(v, key);
         }).join(',');
 
       } else {
-        val = processValueForProp(val, key);
+        val = processTransformValue(val, key);
       }
 
       transformations.push(key + '(' + val + ')');


### PR DESCRIPTION
transform:[{ scale: 0.5 }] was not working

there were a common code to process the style value AND the transform value. This PR split the CSS properties from the transform functions.