### PR TITLE
depends on fbjs ^0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "core-js": "1.2.3",
     "domkit": "0.0.1",
     "easyfile": "0.1.0",
-    "fbjs": "0.2.1",
+    "fbjs": "0.6.1",
     "graceful-fs": "4.1.2",
     "history": "1.12.6",
     "immutable": "3.7.5",


### PR DESCRIPTION
this avoids problem when running `react-native start` when also depending on fbjs at the root (it's required for depending on react and dedup of npm deps)