### PR TITLE
add babel-polyfill support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "babel-eslint": "5.0.0",
     "babel-loader": "6.2.4",
+    "babel-polyfill": "^6.6.1",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-1": "6.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ if (NODE_ENV === 'development') {
     port: PORT,
     devtool: 'source-map',
     entry: [
+      'babel-polyfill',
       'webpack-dev-server/client?http://' + IP + ':' + PORT,
       // 'webpack/hot/only-dev-server',
       config.paths.demoIndex,


### PR DESCRIPTION
We must import babel-polypill lib, if we want to use
async/await on Babel 6, otherwise it will cause ‘regeneratorRuntime is
not defined’ error.