### PR TITLE
ScrollView 和 根节点样式 导致 与客户端显示不一致

### DIFF
--- a/Libraries/ScrollView/ScrollView.web.js
+++ b/Libraries/ScrollView/ScrollView.web.js
@@ -400,7 +400,6 @@ let styles = StyleSheet.create({
     flex: 1,
   },
   contentContainer: {
-    position: 'absolute',
     minWidth: '100%',
   },
   contentContainerHorizontal: {

--- a/Libraries/StyleSheet/setDefaultStyle.web.js
+++ b/Libraries/StyleSheet/setDefaultStyle.web.js
@@ -43,7 +43,7 @@ function appendSytle({
     left: 0;
     right: 0;
     bottom: 0;
-    ${boxStyle}
+    overflow: hidden;
   }
   .${rootClassName} .${viewClassName} {
     position: relative;


### PR DESCRIPTION
> 问题一：ScrollView 中 contentContainer 的样式`position: absolute`，导致ScrollView中内容不占位。
> 问题二：根节点flex box 导致子节点被压缩。与客户端显示不一致

附图：

问题一：
![9ef4de58-91bb-44b3-a099-5a65364a4c50](https://cloud.githubusercontent.com/assets/5719833/15174078/5c3009d8-1792-11e6-8c69-3c0486f379ad.png)

问题二：
![7d6640c6-1d57-4a0b-be76-1701c2aa1174](https://cloud.githubusercontent.com/assets/5719833/15174104/7965c952-1792-11e6-82be-34e06178cd4a.png)

![4ae5a75d-1e11-4219-a5dc-24fee42a1b2a](https://cloud.githubusercontent.com/assets/5719833/15174192/f7c88730-1792-11e6-8144-409181e24e9e.png)

