### PR TITLE
ScrollView 和 Rootstyle 与客户端显示不一致，修复

### DIFF
--- a/Libraries/ScrollView/ScrollView.web.js
+++ b/Libraries/ScrollView/ScrollView.web.js
@@ -19,6 +19,7 @@ import autobind from 'autobind-decorator';
 
 const SCROLLVIEW = 'ScrollView';
 const INNERVIEW = 'InnerScrollView';
+const CONTENT_EXT_STYLE = ['padding', 'paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight'];
 
 /**
  * Component that wraps platform ScrollView while providing
@@ -319,10 +320,24 @@ class ScrollView extends React.Component {
   }
 
   render() {
+    let {
+      style,
+      ...otherProps
+    } = this.props;
+
+    let contentContainerExtStyle = {};
+
+    for (let i = 0; i < CONTENT_EXT_STYLE.length; i++) {
+      if (typeof style[CONTENT_EXT_STYLE[i]] === 'number') {
+        contentContainerExtStyle[CONTENT_EXT_STYLE[i]] = style[CONTENT_EXT_STYLE[i]];
+      }
+    }
+
     let contentContainerStyle = [
       styles.contentContainer,
       this.props.horizontal && styles.contentContainerHorizontal,
       this.props.contentContainerStyle,
+      contentContainerExtStyle,
     ];
     // if (__DEV__ && this.props.style) {
     //   let style = flattenStyle(this.props.style);
@@ -360,7 +375,7 @@ class ScrollView extends React.Component {
     }
 
     let props = {
-      ...this.props,
+      ...otherProps,
       alwaysBounceHorizontal,
       alwaysBounceVertical,
       style: ([styles.base, this.props.style]: ?Array<any>),
@@ -400,6 +415,7 @@ let styles = StyleSheet.create({
     flex: 1,
   },
   contentContainer: {
+    position: 'absolute',
     minWidth: '100%',
   },
   contentContainerHorizontal: {

--- a/Libraries/StyleSheet/setDefaultStyle.web.js
+++ b/Libraries/StyleSheet/setDefaultStyle.web.js
@@ -45,6 +45,9 @@ function appendSytle({
     bottom: 0;
     overflow: hidden;
   }
+  .${rootClassName} > .${viewClassName} {
+    height: 100%;
+  }
   .${rootClassName} .${viewClassName} {
     position: relative;
     ${boxStyle}

--- a/README-zh.md
+++ b/README-zh.md
@@ -150,9 +150,7 @@ var Platform = require('ReactPlatform');
   ```
 5. ScrollView 需要指定高度
   ```js
-  <ScrollView style={{height: 235}} horizontal={true}> // 手动指定滚动区域高度、子元素不会自动撑起ScrollView
-    <View />
-  </ScrollView>
+  <ScrollView style={{height: 235}} horizontal={true}></ScrollView>
   ```
 
 ## 任务脚本

--- a/README-zh.md
+++ b/README-zh.md
@@ -148,6 +148,12 @@ var Platform = require('ReactPlatform');
     LayoutAnimation.configureNext(...)
   }
   ```
+5. ScrollView 需要指定高度
+  ```js
+  <ScrollView style={{height: 235}} horizontal={true}> // 手动指定滚动区域高度、子元素不会自动撑起ScrollView
+    <View />
+  </ScrollView>
+  ```
 
 ## 任务脚本
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ As mentioned above, the HasteResolverPlugin plugin will help webpack to compile 
   }
   ```
 
+5. Should manually specify the height of ScrollView
+  ```js
+  <ScrollView style={{height: 235}} horizontal={true} />
+  ```
+
 ### React Native compatible
 
 #### Components


### PR DESCRIPTION
昨天提交了ScrollView的一些展示不一致的问题，后来使用又发现了一些问题，例如：

1. 如果去掉position: absolute 会让垂直的scrollview显示又会被flex box压缩，所以还是不能去掉。因此还是得手动设置scrollview的高度，不能被子元素撑起来，在文档中标出。
2. 因为内部设置成了position: absolute，因此padding在scrollview中不会生效，所以把它挪到内层。
3. 根节点样式去掉Flex之后第一个不会占满，因此设置一个view的高度100%。

现在已经没问题了