### PR TITLE
React 1.5 CSSPropertyOperations signature fix.

### DIFF
--- a/Libraries/Utilties/NativeMethodsMixin.web.js
+++ b/Libraries/Utilties/NativeMethodsMixin.web.js
@@ -60,7 +60,7 @@ var NativeMethodsMixin = {
    * Manipulation](/react-native/docs/direct-manipulation.html)).
    */
   setNativeProps: function(nativeProps) {
-    setNativeProps(ReactDOM.findDOMNode(this), nativeProps);
+    setNativeProps(ReactDOM.findDOMNode(this), nativeProps, this._reactInternalInstance);
   },
 
   /**

--- a/Libraries/Utilties/setNativeProps.web.js
+++ b/Libraries/Utilties/setNativeProps.web.js
@@ -21,7 +21,7 @@ function convertTransform(style) {
   return result;
 }
 
-function setNativeProps(node, props) {
+function setNativeProps(node, props, component) {
 
   for (var name in props) {
     if (name === 'style') {
@@ -30,7 +30,7 @@ function setNativeProps(node, props) {
         style = convertTransform(style);
       }
 
-      CSSPropertyOperations.setValueForStyles(node, style);
+      CSSPropertyOperations.setValueForStyles(node, style, component);
     } else {
       node.setAttribute(name, props[name]);
     }


### PR DESCRIPTION
Now expects the third "component" argument to be passed.

W/o this an error would be raised:
Cannot read property '_debugID' of undefined

See also: Cannot read property '_debugID' of undefined