### PR TITLE
Build/Importing/Exporting seems currently broken.

### DIFF
--- a/Libraries/react-web.js
+++ b/Libraries/react-web.js
@@ -59,3 +59,10 @@ export StyleSheet from 'ReactStyleSheet';
 export NativeModules from 'ReactNativeModules';
 export Platform from 'ReactPlatform';
 export processColor from 'ReactProcessColor';
+
+
+// Match the react-native export signature, which uses CommonJS
+// (not ES6), where this works:
+//    import ReactNative, {View} from 'react-native';
+//    ReactNative.View === View
+export default module.exports;

--- a/scripts/rewrite-modules.js
+++ b/scripts/rewrite-modules.js
@@ -26,6 +26,8 @@ function mapModule(state, module) {
     var mod = getModule(module, platform);
     if (mod && mod.path) {
       module = path.relative(path.dirname(filePath), mod.path);
+      if (!module.startsWith('.'))
+        module = './' + module;
       module = module.replace('.js', '')
     }
 


### PR DESCRIPTION
Recently, the "publish.js" script was added. The intention behind it, as far as I can tell, is that the built version no longer needs the user to define the "haste" webpack plugin, since all the files are rewritten to reference each other using the regular resolve system.

This doesn't work for me, for a couple of reasons:

1) The ``rewrite_modules`` babel plugin does not handle ES6 imports. I have merged in the changes from the most recent version from ``fbjs``, where imports are supported.

2) At the root level, in ``react-web.js``, the paths being generated are "StyleSheet/StyleSheet.web", but for node's require import to work, they need to be "./StyleSheet/StyleSheet.web".

3) In b903e7ffed387f165e90088002f0249bcd5d852b, the exports in ``react-web.js`` were rewritten to ES6. The problem is that this is incompatible with ``react-native``. For example, the ``react-native-animatable`` Library, which before worked great with ``react-web``, in it's built version tries to access ``reactNative.default.View``, which doesn't exist when react-native uses ES6 exports.

See http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default, http://www.2ality.com/2015/12/babel-commonjs.html
