### PR TITLE
For ES6 classes, we need to use mixin.onClass.

### DIFF
--- a/Libraries/ActivityIndicator/ActivityIndicator.web.js
+++ b/Libraries/ActivityIndicator/ActivityIndicator.web.js
@@ -146,7 +146,7 @@ let styles = StyleSheet.create({
   }
 });
 
-mixin(ActivityIndicator.prototype, NativeMethodsMixin);
+mixin.onClass(ActivityIndicator, NativeMethodsMixin);
 
 ActivityIndicator.isReactNativeComponent = true;
 

--- a/Libraries/DrawerLayout/DrawerLayout.web.js
+++ b/Libraries/DrawerLayout/DrawerLayout.web.js
@@ -268,7 +268,7 @@ let styles = StyleSheet.create({
 });
 
 
-mixin(DrawerLayout.prototype, NativeMethodsMixin);
+mixin.onClass(DrawerLayout, NativeMethodsMixin);
 autobind(DrawerLayout);
 
 DrawerLayout.isReactNativeComponent = true;

--- a/Libraries/Image/Image.web.js
+++ b/Libraries/Image/Image.web.js
@@ -50,8 +50,8 @@ class Image extends React.Component {
   }
 }
 
-mixin(Image.prototype, LayoutMixin);
-mixin(Image.prototype, NativeMethodsMixin);
+mixin.onClass(Image, LayoutMixin);
+mixin.onClass(Image, NativeMethodsMixin);
 
 Image.isReactNativeComponent = true;
 

--- a/Libraries/ListView/ListView.web.js
+++ b/Libraries/ListView/ListView.web.js
@@ -602,8 +602,8 @@ class ListView extends React.Component {
   }
 }
 
-mixin(ListView.prototype, ScrollResponder.Mixin);
-mixin(ListView.prototype, TimerMixin);
+mixin.onClass(ListView, ScrollResponder.Mixin);
+mixin.onClass(ListView, TimerMixin);
 autobind(ListView);
 
 ListView.isReactNativeComponent = true;

--- a/Libraries/ProgressView/ProgressView.web.js
+++ b/Libraries/ProgressView/ProgressView.web.js
@@ -87,7 +87,7 @@ let styles = StyleSheet.create({
   }
 });
 
-mixin(ProgressView.prototype, NativeMethodsMixin);
+mixin.onClass(ProgressView, NativeMethodsMixin);
 autobind(ProgressView);
 ProgressView.isReactNativeComponent = true;
 

--- a/Libraries/ScrollView/ScrollView.web.js
+++ b/Libraries/ScrollView/ScrollView.web.js
@@ -424,7 +424,7 @@ let styles = StyleSheet.create({
   },
 });
 
-mixin(ScrollView.prototype, ScrollResponder.Mixin);
+mixin.onClass(ScrollView, ScrollResponder.Mixin);
 autobind(ScrollView);
 
 ScrollView.isReactNativeComponent = true;

--- a/Libraries/SegmentedControl/SegmentedControl.web.js
+++ b/Libraries/SegmentedControl/SegmentedControl.web.js
@@ -173,7 +173,7 @@ let styles = StyleSheet.create({
   },
 });
 
-mixin(SegmentedControl.prototype, NativeMethodsMixin);
+mixin.onClass(SegmentedControl, NativeMethodsMixin);
 autobind(SegmentedControl);
 
 SegmentedControl.isReactNativeComponent = true;

--- a/Libraries/Switch/Switch.web.js
+++ b/Libraries/Switch/Switch.web.js
@@ -131,7 +131,7 @@ class Switch extends React.Component {
 
 };
 
-mixin(Switch.prototype, NativeMethodsMixin);
+mixin.onClass(Switch, NativeMethodsMixin);
 autobind(Switch);
 
 Switch.isReactNativeComponent = true;

--- a/Libraries/Touchable/TouchableBounce.web.js
+++ b/Libraries/Touchable/TouchableBounce.web.js
@@ -120,7 +120,7 @@ class TouchableBounce extends React.Component {
 
 };
 
-mixin(TouchableBounce.prototype, TouchableMixin);
+mixin.onClass(TouchableBounce, TouchableMixin);
 autobind(TouchableBounce);
 
 module.exports = TouchableBounce;

--- a/Libraries/Touchable/TouchableHighlight.web.js
+++ b/Libraries/Touchable/TouchableHighlight.web.js
@@ -201,9 +201,9 @@ class TouchableHighlight extends React.Component {
 
 };
 
-mixin(TouchableHighlight.prototype, TimerMixin);
-mixin(TouchableHighlight.prototype, TouchableMixin);
-mixin(TouchableHighlight.prototype, NativeMethodsMixin);
+mixin.onClass(TouchableHighlight, TimerMixin);
+mixin.onClass(TouchableHighlight, TouchableMixin);
+mixin.onClass(TouchableHighlight, NativeMethodsMixin);
 autobind(TouchableHighlight);
 
 module.exports = TouchableHighlight;

--- a/Libraries/Touchable/TouchableOpacity.web.js
+++ b/Libraries/Touchable/TouchableOpacity.web.js
@@ -174,9 +174,9 @@ class TouchableOpacity extends React.Component {
  */
 var PRESS_RECT_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 
-mixin(TouchableOpacity.prototype, TimerMixin);
-mixin(TouchableOpacity.prototype, TouchableMixin);
-mixin(TouchableOpacity.prototype, NativeMethodsMixin);
+mixin.onClass(TouchableOpacity, TimerMixin);
+mixin.onClass(TouchableOpacity, TouchableMixin);
+mixin.onClass(TouchableOpacity, NativeMethodsMixin);
 autobind(TouchableOpacity);
 
 module.exports = TouchableOpacity;

--- a/Libraries/Touchable/TouchableWithoutFeedback.web.js
+++ b/Libraries/Touchable/TouchableWithoutFeedback.web.js
@@ -121,7 +121,7 @@ class TouchableWithoutFeedback extends React.Component {
 
 };
 
-mixin(TouchableWithoutFeedback.prototype, Touchable.Mixin);
+mixin.onClass(TouchableWithoutFeedback, Touchable.Mixin);
 autobind(TouchableWithoutFeedback);
 
 module.exports = TouchableWithoutFeedback;

--- a/Libraries/ViewPager/ViewPager.web.js
+++ b/Libraries/ViewPager/ViewPager.web.js
@@ -222,7 +222,7 @@ class ViewPager extends React.Component {
 
 };
 
-mixin(ViewPager.prototype, NativeMethodsMixin);
+mixin.onClass(ViewPager, NativeMethodsMixin);
 autobind(ViewPager);
 
 ViewPager.isReactNativeComponent = true;


### PR DESCRIPTION
Otherwise, the getInitialState etc. helpers for the mixin class
will not be applied.