### PR TITLE
Do not hide errors occuring during publish.js.

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -39,4 +39,4 @@ resolver.getHasteMap().then(function(hasteMap){
     console.log(filePath, '->', buildPath);
 
   })
-});
+}).done();


### PR DESCRIPTION
For example, during the babel transform.