### PR TITLE
修复ios平台浏览器中touchHistory长度与安装平台不一致引起的不兼容问题

### DIFF
--- a/Libraries/Touchable/TouchableHighlight.web.js
+++ b/Libraries/Touchable/TouchableHighlight.web.js
@@ -127,7 +127,7 @@ class TouchableHighlight extends Component {
     this._hideTimeout = this.setTimeout(this._hideUnderlay,
       this.props.delayPressOut || 100);
       
-    var touchBank = e.touchHistory.touchBank[0];
+    var touchBank = e.touchHistory.touchBank[e.touchHistory.touchBank.length - 1];
     var offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2) 
       + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
     var velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;

--- a/Libraries/Touchable/TouchableOpacity.web.js
+++ b/Libraries/Touchable/TouchableOpacity.web.js
@@ -108,7 +108,7 @@ class TouchableOpacity extends React.Component {
       this.props.delayPressOut || 100
     );
     
-    var touchBank = e.touchHistory.touchBank[0];
+    var touchBank = e.touchHistory.touchBank[e.touchHistory.touchBank.length - 1];
     var offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
         + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
     var velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;

--- a/Libraries/Touchable/TouchableWithoutFeedback.web.js
+++ b/Libraries/Touchable/TouchableWithoutFeedback.web.js
@@ -75,7 +75,7 @@ class TouchableWithoutFeedback extends Component {
    * defined on your component.
    */
   touchableHandlePress(e: Event) {
-    var touchBank = e.touchHistory.touchBank[0];
+    var touchBank = e.touchHistory.touchBank[e.touchHistory.touchBank.length - 1];
     var offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
         + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
     var velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;


### PR DESCRIPTION
ios平台中浏览器event.touchHistory对象的长度与安卓平台不一致，导致ios平台下点击出错