### PR TITLE
直接使用 Libraries/ 而非 babel 转换过的 lib/

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -41,4 +41,3 @@ npm-debug.log
 pages
 react-web-cli
 Examples
-Libraries

--- a/Libraries/Image/Image.web.js
+++ b/Libraries/Image/Image.web.js
@@ -13,7 +13,7 @@ import ImageResizeMode from './ImageResizeMode';
 import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 import mixin from 'react-mixin';
 
-class ComponentImage extends Component {
+class Image extends Component {
   static resizeMode = ImageResizeMode
 
   static contextTypes = {
@@ -26,7 +26,7 @@ class ComponentImage extends Component {
     failure: (error: any) => void,
   ) {
     let wrap = document.createElement('div'),
-      img = new Image(),
+      img = new window.Image(),
       loadedHandler = function loadedHandler() {
         img.removeEventListener('load', loadedHandler);
         success && success(img.offsetWidth, img.offsetHeight);
@@ -79,9 +79,9 @@ class ComponentImage extends Component {
   }
 }
 
-mixin.onClass(ComponentImage, LayoutMixin);
-mixin.onClass(ComponentImage, NativeMethodsMixin);
+mixin.onClass(Image, LayoutMixin);
+mixin.onClass(Image, NativeMethodsMixin);
 
-ComponentImage.isReactNativeComponent = true;
+Image.isReactNativeComponent = true;
 
-export default ComponentImage;
+export default Image;

--- a/Libraries/Image/Image.web.js
+++ b/Libraries/Image/Image.web.js
@@ -13,11 +13,40 @@ import ImageResizeMode from './ImageResizeMode';
 import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 import mixin from 'react-mixin';
 
-class Image extends Component {
+class ComponentImage extends Component {
   static resizeMode = ImageResizeMode
 
   static contextTypes = {
     isInAParentText: React.PropTypes.bool
+  }
+
+  static getSize = function(
+    url: string,
+    success: (width: number, height: number) => void,
+    failure: (error: any) => void,
+  ) {
+    let wrap = document.createElement('div'),
+      img = new Image(),
+      loadedHandler = function loadedHandler() {
+        img.removeEventListener('load', loadedHandler);
+        success && success(img.offsetWidth, img.offsetHeight);
+      },
+      errorHandler = function errorHandler() {
+        img.removeEventListener('error', errorHandler);
+        failure && failure();
+      };
+
+    wrap.style.cssText = 'height:0px;width:0px;overflow:hidden;visibility:hidden;';
+
+    wrap.appendChild(img);
+    document.body.appendChild(wrap);
+    img.src = url;
+    if (!img.complete) {
+      img.addEventListener('error', errorHandler);
+      img.addEventListener('load', loadedHandler);
+    } else {
+      loadedHandler();
+    }
   }
 
   render() {
@@ -50,9 +79,9 @@ class Image extends Component {
   }
 }
 
-mixin.onClass(Image, LayoutMixin);
-mixin.onClass(Image, NativeMethodsMixin);
+mixin.onClass(ComponentImage, LayoutMixin);
+mixin.onClass(ComponentImage, NativeMethodsMixin);
 
-Image.isReactNativeComponent = true;
+ComponentImage.isReactNativeComponent = true;
 
-export default Image;
+export default ComponentImage;

--- a/Libraries/LayoutAnimation/LayoutAnimation.web.js
+++ b/Libraries/LayoutAnimation/LayoutAnimation.web.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Alibaba Group Holding Limited.
+ * All rights reserved.
+ *
+ * Copyright (c) 2015, Facebook, Inc.  All rights reserved.
+ *
+ * @providesModule ReactLayoutAnimation
+ */
+"use strict";
+
+var LayoutAnimation = {
+  Types: {},
+  Properties: {},
+  configureNext: function configureNext() {}
+};
+
+module.exports = LayoutAnimation;

--- a/Libraries/LayoutAnimation/Layoutanimation.h5.js
+++ b/Libraries/LayoutAnimation/Layoutanimation.h5.js
@@ -1,9 +1,0 @@
-"use strict";
-
-var LayoutAnimation = {
-  Types: {},
-  Properties: {},
-  configureNext: function configureNext() {}
-};
-
-module.exports = LayoutAnimation;

--- a/Libraries/LayoutAnimation/Layoutanimation.h5.js
+++ b/Libraries/LayoutAnimation/Layoutanimation.h5.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var LayoutAnimation = {
+  Types: {},
+  Properties: {},
+  configureNext: function configureNext() {}
+};
+
+module.exports = LayoutAnimation;

--- a/Libraries/RefreshControl/RefreshControl.web.js
+++ b/Libraries/RefreshControl/RefreshControl.web.js
@@ -1,9 +1,9 @@
 /**
  * Copyright (c) 2015-present, Alibaba Group Holding Limited.
  * All rights reserved.
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- 8
+ *
+ * Copyright (c) 2015, Facebook, Inc.  All rights reserved.
+ *
  * @providesModule ReactRefreshControl
  */
 'use strict';
@@ -18,7 +18,7 @@ let RefreshLayoutConsts = {SIZE: {}};
 
 class RefreshControl extends Component {
 
-  static SIZE = RefreshLayoutConsts.SIZE,
+  static SIZE = RefreshLayoutConsts.SIZE
 
   componentDidMount() {
     this._lastNativeRefreshing = this.props.refreshing;
@@ -45,7 +45,7 @@ class RefreshControl extends Component {
         onRefresh={this._onRefresh}
       />
     );
-  },
+  }
 
   _onRefresh() {
     this._lastNativeRefreshing = true;
@@ -55,8 +55,8 @@ class RefreshControl extends Component {
     // The native component will start refreshing so force an update to
     // make sure it stays in sync with the js component.
     this.forceUpdate();
-  },
-});
+  }
+}
 
 mixin.onClass(RefreshControl, NativeMethodsMixin);
 autobind(RefreshControl);

--- a/Libraries/Touchable/TouchableHighlight.web.js
+++ b/Libraries/Touchable/TouchableHighlight.web.js
@@ -126,12 +126,16 @@ class TouchableHighlight extends Component {
     this._showUnderlay();
     this._hideTimeout = this.setTimeout(this._hideUnderlay,
       this.props.delayPressOut || 100);
-      
+
     var touchBank = e.touchHistory.touchBank[e.touchHistory.indexOfSingleActiveTouch];
-    var offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2) 
-      + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
-    var velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;
-    if (velocity < 100) this.props.onPress && this.props.onPress(e);
+    if (touchBank) {
+      var offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
+          + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
+      var velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;
+      if (velocity < 100) this.props.onPress && this.props.onPress(e);
+    } else {
+      this.props.onPress && this.props.onPress(e);
+    }
   }
 
   touchableHandleLongPress(e: Event) {

--- a/Libraries/Touchable/TouchableOpacity.web.js
+++ b/Libraries/Touchable/TouchableOpacity.web.js
@@ -107,12 +107,16 @@ class TouchableOpacity extends React.Component {
       this._opacityInactive,
       this.props.delayPressOut || 100
     );
-    
+
     var touchBank = e.touchHistory.touchBank[e.touchHistory.indexOfSingleActiveTouch];
-    var offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
-        + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
-    var velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;
-    if (velocity < 100) this.props.onPress && this.props.onPress(e);
+    if (touchBank) {
+      var offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
+          + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
+      var velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;
+      if (velocity < 100) this.props.onPress && this.props.onPress(e);
+    } else {
+      this.props.onPress && this.props.onPress(e);
+    }
   }
 
   touchableHandleLongPress(e: Event) {

--- a/Libraries/Touchable/TouchableWithoutFeedback.web.js
+++ b/Libraries/Touchable/TouchableWithoutFeedback.web.js
@@ -76,10 +76,14 @@ class TouchableWithoutFeedback extends Component {
    */
   touchableHandlePress(e: Event) {
     var touchBank = e.touchHistory.touchBank[e.touchHistory.indexOfSingleActiveTouch];
-    var offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
-        + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
-    var velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;
-    if (velocity < 100) this.props.onPress && this.props.onPress(e);
+    if (touchBank) {
+      var offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
+          + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
+      var velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;
+      if (velocity < 100) this.props.onPress && this.props.onPress(e);
+    } else {
+      this.props.onPress && this.props.onPress(e);
+    }
   }
 
   touchableHandleActivePressIn(e: Event) {

--- a/Libraries/react-web.js
+++ b/Libraries/react-web.js
@@ -57,6 +57,7 @@ export AsyncStorage from 'ReactAsyncStorage';
 export Dimensions from 'ReactDimensions';
 export Easing from 'animated/lib/Easing';
 export InteractionManager from 'ReactInteractionManager';
+export LayoutAnimation from 'ReactLayoutAnimation';
 export PanResponder from 'ReactPanResponder';
 export PixelRatio from 'ReactPixelRatio';
 export StyleSheet from 'ReactStyleSheet';

--- a/Libraries/react-web.js
+++ b/Libraries/react-web.js
@@ -42,7 +42,7 @@ export TouchableHighlight from 'ReactTouchableHighlight';
 export TouchableOpacity from 'ReactTouchableOpacity';
 export TouchableWithoutFeedback from 'ReactTouchableWithoutFeedback';
 export TouchableBounce from 'ReactTouchableBounce';
-// export RefreshControl from 'ReactRefreshControl';
+export RefreshControl from 'ReactRefreshControl';
 export View from 'ReactView';
 export ViewPagerAndroid from 'ReactViewPager';
 export ViewPager from 'ReactViewPager';

--- a/Libraries/react-web.js
+++ b/Libraries/react-web.js
@@ -17,6 +17,7 @@ export * from 'react';
 
 // Components
 export ActivityIndicatorIOS from 'ReactActivityIndicator';
+export ActivityIndicator from 'ReactActivityIndicator';
 // export DatePicker from 'ReactDatePicker';
 export DrawerLayoutAndroid from 'ReactDrawerLayout';
 export Image from 'ReactImage';

--- a/README-zh.md
+++ b/README-zh.md
@@ -16,7 +16,7 @@
 ## 安装
 
 ```
-npm install react-web --save
+npm install --save git+https://github.com/flyskywhy/react-web.git
 ```
 
 ## 使用

--- a/README-zh.md
+++ b/README-zh.md
@@ -16,7 +16,7 @@
 ## 安装
 
 ```
-npm install --save git+https://github.com/flyskywhy/react-web.git
+npm install --save git+https://github.com/taobaofed/react-web.git
 ```
 
 ## 使用

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ As mentioned above, the HasteResolverPlugin plugin will help webpack to compile 
 #### Components
 
 * ActivityIndicatorIOS - ReactActivityIndicator
+* ActivityIndicator - ReactActivityIndicator
 * DatePickerIOS - ReactDatePicker *TODO*
 * DrawerLayoutAndroid - ReactDrawerLayout
 * Image - ReactImage
@@ -177,6 +178,7 @@ As mentioned above, the HasteResolverPlugin plugin will help webpack to compile 
 * Switch - ReactSwitch
 * SwitchAndroid - ReactSwitch
 * SwitchIOS - ReactSwitch
+* RefreshControl - ReactRefreshControl
 * TabBarIOS - ReactTabBar
 * Text - ReactText
 * TextInput - ReactTextInput
@@ -198,6 +200,7 @@ As mentioned above, the HasteResolverPlugin plugin will help webpack to compile 
 * Dimensions - ReactDimensions
 * Easing - ReactEasing
 * InteractionManager - ReactInteractionManager
+* LayoutAnimation - ReactLayoutAnimation
 * PanResponder - ReactPanResponder
 * PixelRatio - ReactPixelRatio
 * StyleSheet - ReactStyleSheet

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you already have a React Native project and want to add web support, you need
 1. Install `npm install react-web-cli -g`
 2. Execute `react-web init <ExistedProjectDir>`. That install `react-web` and `devDependencies` to your project and make a `web` directory with `webpack.config.js` file under your project
 3. Register your app into a web platform. To do so, add the code from **Fix platform differences. 2. Should run application on web platform** to your index.ios.js file
-4. Execute `npm install --save git+https://github.com/flyskywhy/react-web.git` that replace react-web npm version to develope react-web itself easier
+4. Execute `npm install --save git+https://github.com/taobaofed/react-web.git` that replace react-web npm version to develope react-web itself easier
 5. Execute `react-web start` that starts the web dev server
 6. Execute `react-web bundle` that builds the output
 
@@ -36,7 +36,7 @@ If you already have a React Native project and want to add web support, you need
 ### Install
 
 ```sh
-npm install --save git+https://github.com/flyskywhy/react-web.git
+npm install --save git+https://github.com/taobaofed/react-web.git
 ```
 
 ### Add Webpack configuration

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you already have a React Native project and want to add web support, you need
 1. Install `npm install react-web-cli -g`
 2. Execute `react-web init <ExistedProjectDir>`. That install `react-web` and `devDependencies` to your project and make a `web` directory with `webpack.config.js` file under your project
 3. Register your app into a web platform. To do so, add the code from **Fix platform differences. 2. Should run application on web platform** to your index.ios.js file
-4. Execute `npm start`
+4. Execute `npm install --save git+https://github.com/flyskywhy/react-web.git` that replace react-web npm version to develope react-web itself easier
 5. Execute `react-web start` that starts the web dev server
 6. Execute `react-web bundle` that builds the output
 
@@ -36,7 +36,7 @@ If you already have a React Native project and want to add web support, you need
 ### Install
 
 ```sh
-npm install react-web --save
+npm install --save git+https://github.com/flyskywhy/react-web.git
 ```
 
 ### Add Webpack configuration

--- a/local-cli/generator-web/templates/webpack.config.js
+++ b/local-cli/generator-web/templates/webpack.config.js
@@ -23,7 +23,7 @@ var config = {
 var webpackConfig = {
   ip: IP,
   port: PORT,
-  devtool: 'source-map',
+  devtool: 'cheap-module-eval-source-map',
   resolve: {
     alias: {
       'react-native': 'ReactWeb',

--- a/local-cli/generator-web/templates/webpack.config.js
+++ b/local-cli/generator-web/templates/webpack.config.js
@@ -73,7 +73,7 @@ var webpackConfig = {
         presets: ['es2015', 'react', 'stage-1']
       },
       include: [config.paths.src],
-      exclude: [/node_modules/]
+      exclude: /(node_modules\/(?!react))/
     }]
   }
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:taobaofed/react-web.git"
   },
-  "main": "./lib/react-web.js",
+  "main": "./Libraries/react-web.js",
   "keywords": [
     "react-native",
     "react-web",


### PR DESCRIPTION
实际使用 react-web 经常会需要修改 react-web 本身，而经过 babel 转换过的代码修改起来太累。在看到 react-native 和一些 react-native 第三方库比如 react-native-scrollable-tab-view 都直接在 node_modules/ 中呈现未经 babel 转换的代码后，以及为了能直接让 react-web start 使用那些 react-native 第三方库，所以我做了这些修改，主要是通过 webpack.config.js 中的 exclude: /(node_modules\/(?!react))/ 让 babel 在编译/运行 APP 的过程中去处理 node_modules/react*，如果你们接受这个 pull request 的话，我觉得你们只需要将 npm install --save git+https://github.com/flyskywhy/react-web.git 这句修改成你们的 github 地址合并到 react-web init 的脚本中，并修改 README.md 中相应的地方。

另外还修改了Touchable 组件的 BUG ，以及添加了 LayoutAnimation 和 RefreshControl 这两个组件，在 Image 组件中添加了 getSize()。

还有就是在 webpack.config.js 中使用了 cheap-module-eval-source-map ，这样调试 BUG 时就能很容易定位到精确的源代码文件而不是找不到北的 bundle.js

在经过这些修改后， https://github.com/flyskywhy/noder-react-native 就能正常运行 web 版了

附： 我看到 携程 的 react-web 修改版 https://www.npmjs.com/package/moles-web 中添加了不少新组件，你们是否能其合并过来？