### PR TITLE
fix `react-web init --version <alternative react-web package> <ExistedProjectDir>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@
 If you already have a React Native project and want to add web support, you need to execute the following commands in your existing project directory:
 
 1. Install `npm install react-web-cli -g`
-2. Execute `react-web init <ExistedProjectDir>`. That install `react-web` and `devDependencies` to your project and make a `web` directory with `webpack.config.js` file under your project
+2. Execute `react-web init <ExistedProjectDir>` to install stable npm version, or execute `react-web init --version git+https://github.com/taobaofed/react-web.git <ExistedProjectDir>` to install latest git version. That install `react-web` and `devDependencies` to your project and make a `web` directory with `webpack.config.js` file under your project
 3. Register your app into a web platform. To do so, add the code from **Fix platform differences. 2. Should run application on web platform** to your index.ios.js file
-4. Execute `npm install --save git+https://github.com/taobaofed/react-web.git` that replace react-web npm version to develope react-web itself easier
-5. Execute `react-web start` that starts the web dev server
-6. Execute `react-web bundle` that builds the output
+4. Execute `react-web start` that starts the web dev server
+5. Execute `react-web bundle` that builds the output
 
 ## Getting Started
 

--- a/react-web-cli/index.js
+++ b/react-web-cli/index.js
@@ -241,7 +241,7 @@ function runVerbose(root, projectName, rwPackage) {
 }
 
 function checkForVersionArgument() {
-  if (process.argv.indexOf('-v') >= 0 || process.argv.indexOf('--version') >= 0) {
+  if (argv._.length === 0 && (argv.v || argv.version)) {
     console.log('react-web-cli: ' + require('./package.json').version);
     try {
       console.log('react-web: ' + require(REACT_WEB_PACKAGE_JSON_PATH()).version);


### PR DESCRIPTION
fix `react-web init --version <alternative react-web package>`, ref to react-native-cli