### PR TITLE
adds support for ...Platform.select (React 15)

### DIFF
--- a/Libraries/Platform/Platform.web.js
+++ b/Libraries/Platform/Platform.web.js
@@ -9,6 +9,9 @@
 
 const Platform = {
   OS: 'web',
+  select:(platform) => {
+    return platform.web || platform.ios;
+  },
 };
 
 module.exports = Platform;


### PR DESCRIPTION
https://facebook.github.io/react-native/docs/platform-specific-code.html

There is also a Platform.select method available, that given an object containing Platform.OS as keys, returns the value for the platform you are currently running on.