### PR TITLE
Add .web.js support

### DIFF
--- a/local-cli/generator-web/templates/webpack.config.js
+++ b/local-cli/generator-web/templates/webpack.config.js
@@ -28,7 +28,7 @@ var webpackConfig = {
     alias: {
       'react-native': 'ReactWeb',
     },
-    extensions: ['', '.js', '.ios.js', '.android.js', '.jsx'],
+    extensions: ['', '.js', '.web.js', '.ios.js', '.android.js', '.jsx'],
   },
   entry: isProd? [
     config.paths.index


### PR DESCRIPTION
As I checked bundle.js again and again, webpack will bundle the first matched from left to right order in resolve.extensions['.web.js', '.ios.js', '.android.js'], so this PR will resolve .web.js issue #95 and #143 and stlll meet the demand of .ios.js and .android.js in PR #93 