### PR TITLE
ensure default to cursor pointer for TouchableHighlight / TouchableOpacity

### DIFF
--- a/Libraries/Touchable/TouchableHighlight.web.js
+++ b/Libraries/Touchable/TouchableHighlight.web.js
@@ -23,9 +23,9 @@ type Event = Object;
 var DEFAULT_PROPS = {
   activeOpacity: 0.8,
   underlayColor: 'black',
-  style: {
+  style: StyleSheet.create({
     cursor: 'pointer'
-  }
+  })
 };
 
 var PRESS_RECT_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
@@ -79,6 +79,7 @@ class TouchableHighlight extends Component {
         }
       },
       underlayStyle: [
+        DEFAULT_PROPS.style,
         INACTIVE_UNDERLAY_PROPS.style,
         props.style,
       ]

--- a/Libraries/Touchable/TouchableOpacity.web.js
+++ b/Libraries/Touchable/TouchableOpacity.web.js
@@ -16,6 +16,7 @@ import TouchableWithoutFeedback from 'ReactTouchableWithoutFeedback';
 import { Mixin as NativeMethodsMixin } from 'NativeMethodsMixin';
 import mixin from 'react-mixin';
 import autobind from 'autobind-decorator';
+import StyleSheet from 'ReactStyleSheet';
 
 // var ensurePositiveDelayProps = require('ensurePositiveDelayProps');
 var flattenStyle = require('ReactFlattenStyle');
@@ -44,6 +45,13 @@ type Event = Object;
  * ```
  */
 
+const DEFAULT_PROPS = {
+  activeOpacity: 0.2,
+  style: StyleSheet.create({
+    cursor: 'pointer'
+  })
+}
+
 class TouchableOpacity extends React.Component {
 
   static propTypes = {
@@ -53,14 +61,9 @@ class TouchableOpacity extends React.Component {
      * active.
      */
     activeOpacity: React.PropTypes.number,
-  }
+  };
 
-  static defaultProps ={
-    activeOpacity: 0.2,
-    style: {
-      cursor: 'pointer'
-    }
-  }
+  static defaultProps = DEFAULT_PROPS;
 
   state = {
     ...this.touchableGetInitialState(),
@@ -159,7 +162,7 @@ class TouchableOpacity extends React.Component {
         accessible={true}
         accessibilityComponentType={this.props.accessibilityComponentType}
         accessibilityTraits={this.props.accessibilityTraits}
-        style={[this.props.style, {opacity: this.state.anim}]}
+        style={[DEFAULT_PROPS.style, this.props.style, {opacity: this.state.anim}]}
         testID={this.props.testID}
         onLayout={this.props.onLayout}
         onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}


### PR DESCRIPTION
looks like i didn't finish the job in #90 

problem: any styles passed in to TouchableHighlight/Opacity override defaultProps.style, and result in a select (not pointer) cursor