### PR TITLE
Windows development support

### DIFF
--- a/local-cli/generator-web/index.js
+++ b/local-cli/generator-web/index.js
@@ -11,7 +11,7 @@ var easyfile = require('easyfile');
 var packageJson = require('../../package.json');
 
 function installDev(projectDir, verbose) {
-  var proc = spawn('npm', [
+  var proc = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', [
     'install',
     verbose? '--verbose': '',
     '--save-dev',

--- a/local-cli/generator-web/templates/webpack.config.js
+++ b/local-cli/generator-web/templates/webpack.config.js
@@ -73,7 +73,7 @@ var webpackConfig = {
         presets: ['react-native', 'stage-1']
       },
       include: [config.paths.src],
-      exclude: /(node_modules\/(?!react))/
+      exclude: [path.sep === '/' ? /(node_modules\/(?!react))/ : /(node_modules\\(?!react))/]
     }]
   }
 };

--- a/local-cli/generator-web/templates/webpack.config.js
+++ b/local-cli/generator-web/templates/webpack.config.js
@@ -30,9 +30,9 @@ var webpackConfig = {
     },
     extensions: ['', '.js', '.web.js', '.ios.js', '.android.js', '.jsx'],
   },
-  entry: isProd? [
+  entry: isProd ? [
     config.paths.index
-  ]: [
+  ] : [
     'webpack-dev-server/client?http://' + IP + ':' + PORT,
     'webpack/hot/only-dev-server',
     config.paths.index,
@@ -48,12 +48,12 @@ var webpackConfig = {
     }),
     new webpack.DefinePlugin({
       'process.env': {
-        'NODE_ENV': JSON.stringify(isProd? PROD: DEV),
+        'NODE_ENV': JSON.stringify(isProd ? PROD : DEV),
       }
     }),
-    isProd? new webpack.ProvidePlugin({
-      React: "react"
-    }): new webpack.HotModuleReplacementPlugin(),
+    isProd ? new webpack.ProvidePlugin({
+      React: 'react'
+    }) : new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new HtmlPlugin(),
   ],

--- a/react-web-cli/index.js
+++ b/react-web-cli/index.js
@@ -228,7 +228,7 @@ function run(root, projectName, rwPackage) {
 }
 
 function runVerbose(root, projectName, rwPackage) {
-  var proc = spawn('npm', ['install', '--verbose', '--save', '--save-exact', getInstallPackage(rwPackage)], {stdio: 'inherit'});
+  var proc = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--verbose', '--save', '--save-exact', getInstallPackage(rwPackage)], {stdio: 'inherit'});
   proc.on('close', function (code) {
     if (code !== 0) {
       console.error('`npm install --save --save-exact react-web` failed');


### PR DESCRIPTION
`react-web init`:
This PR fixed ENOENT on Windows that described in #131 

`react-web start`:
 This PR fixed an error on Windows, and the remaining `react-web start` error on Windows described in #173 need another PR https://github.com/yuanyan/haste-resolver/pull/2