### PR TITLE
Fix `react-web init` on Windows Error again

### DIFF
--- a/local-cli/generator-web/index.js
+++ b/local-cli/generator-web/index.js
@@ -11,7 +11,7 @@ var easyfile = require('easyfile');
 var packageJson = require('../../package.json');
 
 function installDev(projectDir, verbose) {
-  var proc = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', [
+  var proc = spawn('npm', [
     'install',
     verbose? '--verbose': '',
     '--save-dev',


### PR DESCRIPTION
Fix `react-web init` on Windows `Error: Cannot find module 'D:\proj\RN\node_modules\npm\bin\npm-cli.js'`

也请再发个新版到 https://www.npmjs.com/package/react-web 上，以便 `react-web init RN` 这样的命令能在 Windows 下正常执行，谢谢