### PR TITLE
Avoid source map debugging to useless file `?d41d`

### DIFF
--- a/Libraries/StatusBar/StatusBar.web.js
+++ b/Libraries/StatusBar/StatusBar.web.js
@@ -11,17 +11,15 @@ import React from 'react';
 
 var emptyFunction = function() {};
 
-var StatusBar = React.createClass({
-  setHidden: emptyFunction,
-  setBarStyle: emptyFunction,
-  setNetworkActivityIndicatorVisible: emptyFunction,
-  setBackgroundColor: emptyFunction,
-  setTranslucent: emptyFunction,
-  render: function() {
-    return <div />;
-  },
-});
+function StatusBar() {
+  return null;
+}
 
+StatusBar.setBarStyle = emptyFunction;
+StatusBar.setHidden = emptyFunction;
+StatusBar.setNetworkActivityIndicatorVisible = emptyFunction;
+StatusBar.setBackgroundColor = emptyFunction;
+StatusBar.setTranslucent = emptyFunction;
 StatusBar.isReactNativeComponent = true;
 
 export default StatusBar;

--- a/Libraries/StatusBar/StatusBar.web.js
+++ b/Libraries/StatusBar/StatusBar.web.js
@@ -7,14 +7,21 @@
 
 'use strict';
 
+import React from 'react';
+
 var emptyFunction = function() {};
 
-var StatusBar = {
+var StatusBar = React.createClass({
   setHidden: emptyFunction,
   setBarStyle: emptyFunction,
   setNetworkActivityIndicatorVisible: emptyFunction,
   setBackgroundColor: emptyFunction,
   setTranslucent: emptyFunction,
-};
+  render: function() {
+    return <div />;
+  },
+});
 
-module.exports = StatusBar;
+StatusBar.isReactNativeComponent = true;
+
+export default StatusBar;

--- a/local-cli/generator-web/templates/webpack.config.js
+++ b/local-cli/generator-web/templates/webpack.config.js
@@ -73,7 +73,7 @@ var webpackConfig = {
         presets: ['react-native', 'stage-1']
       },
       include: [config.paths.src],
-      exclude: [path.sep === '/' ? /(node_modules\/(?!react))/ : /(node_modules\\(?!react))/]
+      exclude: [path.sep === '/' ? /(node_modules\/(?!react-))/ : /(node_modules\\(?!react-))/]
     }]
   }
 };


### PR DESCRIPTION
1. Fix <StatusBar /> will cause `Uncaught Invariant Violation: Element type is invalid`, so that no need 
```
    {Platform.OS !== 'web' && (
                    <StatusBar
                        ......
                    />
    )}
```
on exist react-native project.

2. Avoid source map debugging to useless file `?d41d` by not babel node_modules/react/ in `webpack.config.js`
as you can see, before:
![image](https://cloud.githubusercontent.com/assets/1439846/19918553/30a79d4a-a107-11e6-8ca8-b37469447a99.png)

after:
![image](https://cloud.githubusercontent.com/assets/1439846/19918579/6584d0e6-a107-11e6-90b1-4fac4c7e1a2d.png)